### PR TITLE
PR: Adição de utilitários para padronização de mensagens de sucesso e erro

### DIFF
--- a/src/utils/errors-messages.ts
+++ b/src/utils/errors-messages.ts
@@ -1,0 +1,27 @@
+import Boom from "@hapi/boom";
+
+export function errorsResponse(
+  statusCode: number,
+  message?: string,
+  details?: unknown
+) {
+  switch (statusCode) {
+    case 400:
+      return Boom.badRequest(message ?? "Requisição inválida", details);
+    case 401:
+      return Boom.unauthorized(message ?? "Não autorizado");
+    case 403:
+      return Boom.forbidden(message ?? "Acesso proibido", details);
+    case 404:
+      return Boom.notFound(message ?? "Recurso não encontrado", details);
+    case 409:
+      return Boom.conflict(message ?? "Conflito na requisição", details);
+    case 500:
+      return Boom.internal(message ?? "Erro interno do servidor", details);
+    default:
+      return Boom.boomify(new Error(message ?? "Erro desconhecido"), {
+        statusCode,
+        data: details,
+      });
+  }
+}

--- a/src/utils/success-messages.ts
+++ b/src/utils/success-messages.ts
@@ -1,0 +1,39 @@
+const statusMessages: Record<number, string> = {
+  200: "Requisição bem-sucedida",
+  201: "Recurso criado com sucesso",
+  204: "Sem conteúdo, mas operação concluída",
+};
+
+export function successResponse<T>(
+  data: T,
+  statusCode: number,
+  message?: string,
+  details?: unknown
+) {
+  switch (statusCode) {
+    case 200:
+      return {
+        statusCode,
+        message: message ?? statusMessages[200],
+        data,
+      };
+    case 201:
+      return {
+        statusCode,
+        message: message ?? statusMessages[201],
+        data,
+      };
+    case 204:
+      return {
+        statusCode,
+        message: message ?? statusMessages[204],
+        data,
+      };
+    default:
+      return {
+        statusCode,
+        message: message ?? "Operação realizada com sucesso",
+        data,
+      };
+  }
+}


### PR DESCRIPTION
# 🔀 Pull Request: Adição de utilitários para padronização de mensagens de sucesso e erro

## 📦 Tipo de mudança
- `feat`: Adição de utilitários para padronização de mensagens de sucesso e erro

---

## ✨ Descrição

Este PR adiciona novos utilitários no módulo `src/utils` que padronizam as mensagens de sucesso e erro utilizando a biblioteca `boom`.  
Agora todos os módulos podem retornar respostas consistentes e centralizadas, facilitando manutenção e legibilidade do código.

---

## 📁 Arquivos modificados
- `src/utils/*`

---

## 👤 Autor
- @kailanesarah

---

## 🧪 Checklist
- [x] Código segue o padrão de estilo do projeto  
- [x] Não há quebras na aplicação após as mudanças  
- [x] Testado manualmente em ambiente local  
- [x] Mensagens de erro e sucesso estão p
